### PR TITLE
Flatten the LocationHierarchy endpoint response

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,19 @@ Example:
 [GET] /List?_id=<some-id>&_count=<page-size>&_page=<page-number>&_sort=<some-sort>
 ```
 
+##### LocationHierarchy list mode
+
+The LocationHierarchy endpoint supports two response formats: tree and list. By
+default, the response format remains a tree, providing hierarchical location
+data. In addition, clients can request the endpoint to return location resources
+in a flat list format by providing a request parameter `mode=list`.
+
+Example:
+
+```
+[GET] /LocationHierarchy?identifier=<some-location-id>&mode=list&_count=<page-size>&_page=<page-number>&_sort=<some-sort>
+```
+
 #### Important Note:
 
 Developers, please update your client applications accordingly to accommodate

--- a/exec/pom.xml
+++ b/exec/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.smartregister</groupId>
     <artifactId>opensrp-gateway-plugin</artifactId>
-    <version>1.0.8</version>
+    <version>1.0.9</version>
   </parent>
 
   <artifactId>exec</artifactId>
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>org.smartregister</groupId>
       <artifactId>plugins</artifactId>
-      <version>1.0.8</version>
+      <version>1.0.9</version>
     </dependency>
 
     <dependency>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.smartregister</groupId>
     <artifactId>opensrp-gateway-plugin</artifactId>
-    <version>1.0.8</version>
+    <version>1.0.9</version>
   </parent>
 
   <artifactId>plugins</artifactId>

--- a/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/BaseEndpoint.java
+++ b/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/BaseEndpoint.java
@@ -11,7 +11,7 @@ import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Resource;
 
 public abstract class BaseEndpoint extends HttpServlet {
-    public Bundle createBundle(List<Resource> resourceList) {
+    public static Bundle createBundle(List<Resource> resourceList) {
         Bundle responseBundle = new Bundle();
         List<Bundle.BundleEntryComponent> bundleEntryComponentList = new ArrayList<>();
 
@@ -24,7 +24,7 @@ public abstract class BaseEndpoint extends HttpServlet {
         return responseBundle;
     }
 
-    public Bundle createEmptyBundle(String requestURL) {
+    public static Bundle createEmptyBundle(String requestURL) {
         Bundle responseBundle = new Bundle();
         responseBundle.setId(UUID.randomUUID().toString());
         Bundle.BundleLinkComponent linkComponent = new Bundle.BundleLinkComponent();

--- a/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/BaseEndpoint.java
+++ b/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/BaseEndpoint.java
@@ -1,38 +1,5 @@
 package org.smartregister.fhir.gateway.plugins;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
-
 import javax.servlet.http.HttpServlet;
 
-import org.hl7.fhir.r4.model.Bundle;
-import org.hl7.fhir.r4.model.Resource;
-
-public abstract class BaseEndpoint extends HttpServlet {
-    public static Bundle createBundle(List<Resource> resourceList) {
-        Bundle responseBundle = new Bundle();
-        List<Bundle.BundleEntryComponent> bundleEntryComponentList = new ArrayList<>();
-
-        for (Resource resource : resourceList) {
-            bundleEntryComponentList.add(new Bundle.BundleEntryComponent().setResource(resource));
-        }
-
-        responseBundle.setEntry(bundleEntryComponentList);
-        responseBundle.setTotal(bundleEntryComponentList.size());
-        return responseBundle;
-    }
-
-    public static Bundle createEmptyBundle(String requestURL) {
-        Bundle responseBundle = new Bundle();
-        responseBundle.setId(UUID.randomUUID().toString());
-        Bundle.BundleLinkComponent linkComponent = new Bundle.BundleLinkComponent();
-        linkComponent.setRelation(Bundle.LINK_SELF);
-        linkComponent.setUrl(requestURL);
-        responseBundle.setLink(Collections.singletonList(linkComponent));
-        responseBundle.setType(Bundle.BundleType.SEARCHSET);
-        responseBundle.setTotal(0);
-        return responseBundle;
-    }
-}
+public abstract class BaseEndpoint extends HttpServlet {}

--- a/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/BaseEndpoint.java
+++ b/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/BaseEndpoint.java
@@ -2,4 +2,10 @@ package org.smartregister.fhir.gateway.plugins;
 
 import javax.servlet.http.HttpServlet;
 
-public abstract class BaseEndpoint extends HttpServlet {}
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.parser.IParser;
+
+public abstract class BaseEndpoint extends HttpServlet {
+    protected final FhirContext fhirR4Context = FhirContext.forR4();
+    protected final IParser fhirR4JsonParser = fhirR4Context.newJsonParser().setPrettyPrint(true);
+}

--- a/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/CacheHelper.java
+++ b/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/CacheHelper.java
@@ -6,6 +6,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.r4.model.DomainResource;
+import org.hl7.fhir.r4.model.Location;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
@@ -16,6 +17,8 @@ public enum CacheHelper {
 
     Cache<String, DomainResource> resourceCache;
 
+    Cache<String, List<Location>> locationListCache;
+
     CacheHelper() {
         cache =
                 Caffeine.newBuilder()
@@ -23,6 +26,11 @@ public enum CacheHelper {
                         .maximumSize(DEFAULT_CACHE_SIZE)
                         .build();
         resourceCache =
+                Caffeine.newBuilder()
+                        .expireAfterWrite(getCacheExpiryDurationInSeconds(), TimeUnit.SECONDS)
+                        .maximumSize(DEFAULT_CACHE_SIZE)
+                        .build();
+        locationListCache =
                 Caffeine.newBuilder()
                         .expireAfterWrite(getCacheExpiryDurationInSeconds(), TimeUnit.SECONDS)
                         .maximumSize(DEFAULT_CACHE_SIZE)

--- a/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/Constants.java
+++ b/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/Constants.java
@@ -35,6 +35,7 @@ public class Constants {
     public static final String ROLE_ALL_LOCATIONS = "ALL_LOCATIONS";
     public static final String MODE = "mode";
     public static final String LIST = "list";
+    public static final String FLAT_PREFIX = "flat-";
 
     public interface Literals {
         String EQUALS = "=";

--- a/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/Constants.java
+++ b/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/Constants.java
@@ -33,6 +33,8 @@ public class Constants {
     public static final String DEFAULT_RELATED_ENTITY_TAG_URL =
             "https://smartregister.org/related-entity-location-tag-id";
     public static final String ROLE_ALL_LOCATIONS = "ALL_LOCATIONS";
+    public static final String MODE = "mode";
+    public static final String LIST = "list";
 
     public interface Literals {
         String EQUALS = "=";

--- a/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/Constants.java
+++ b/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/Constants.java
@@ -35,7 +35,6 @@ public class Constants {
     public static final String ROLE_ALL_LOCATIONS = "ALL_LOCATIONS";
     public static final String MODE = "mode";
     public static final String LIST = "list";
-    public static final String FLAT_PREFIX = "flat-";
 
     public interface Literals {
         String EQUALS = "=";

--- a/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/LocationHierarchyEndpoint.java
+++ b/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/LocationHierarchyEndpoint.java
@@ -3,7 +3,9 @@ package org.smartregister.fhir.gateway.plugins;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.servlet.annotation.WebServlet;
@@ -11,6 +13,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.http.HttpStatus;
+import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Location;
 import org.hl7.fhir.r4.model.Resource;
 import org.smartregister.model.location.LocationHierarchy;
@@ -44,6 +47,21 @@ public class LocationHierarchyEndpoint extends BaseEndpoint {
             RestUtils.checkAuthentication(request, tokenVerifier);
             String identifier = request.getParameter(Constants.IDENTIFIER);
             String mode = request.getParameter(Constants.MODE);
+            String pageSize = request.getParameter(Constants.PAGINATION_PAGE_SIZE);
+            String pageNumber = request.getParameter(Constants.PAGINATION_PAGE_NUMBER);
+            Map<String, String[]> parameters = new HashMap<>(request.getParameterMap());
+
+            int count =
+                    pageSize != null
+                            ? Integer.parseInt(pageSize)
+                            : Constants.PAGINATION_DEFAULT_PAGE_SIZE;
+            int page =
+                    pageNumber != null
+                            ? Integer.parseInt(pageNumber)
+                            : Constants.PAGINATION_DEFAULT_PAGE_NUMBER;
+
+            int start = Math.max(0, (page - 1)) * count;
+
             String resultContent;
             if (Objects.equals(mode, Constants.LIST)) {
                 Location parentLocation =
@@ -51,6 +69,11 @@ public class LocationHierarchyEndpoint extends BaseEndpoint {
                 List<Location> locations =
                         locationHierarchyEndpointHelper.getDescendants(identifier, parentLocation);
                 List<Resource> resourceLocations = new ArrayList<>(locations);
+                int totalEntries = locations.size();
+                int end = Math.min(start + count, resourceLocations.size());
+
+                List<Resource> paginatedResourceLocations = resourceLocations.subList(start, end);
+
                 if (locations.isEmpty()) {
                     resultContent =
                             fhirR4JsonParser.encodeResourceToString(
@@ -59,9 +82,17 @@ public class LocationHierarchyEndpoint extends BaseEndpoint {
                                                     + "?"
                                                     + request.getQueryString()));
                 } else {
-                    resultContent =
-                            fhirR4JsonParser.encodeResourceToString(
-                                    createBundle(resourceLocations));
+                    Bundle resultBundle = createBundle(paginatedResourceLocations);
+                    StringBuilder urlBuilder = new StringBuilder(request.getRequestURL());
+                    resultBundle =
+                            SyncAccessDecision.addPaginationLinks(
+                                    urlBuilder,
+                                    resultBundle,
+                                    page,
+                                    totalEntries,
+                                    count,
+                                    parameters);
+                    resultContent = fhirR4JsonParser.encodeResourceToString(resultBundle);
                 }
 
             } else {

--- a/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/LocationHierarchyEndpoint.java
+++ b/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/LocationHierarchyEndpoint.java
@@ -2,7 +2,6 @@ package org.smartregister.fhir.gateway.plugins;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.Objects;
 
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -43,7 +42,7 @@ public class LocationHierarchyEndpoint extends BaseEndpoint {
             String mode = request.getParameter(Constants.MODE);
 
             String resultContent;
-            if (Objects.equals(mode, Constants.LIST)) {
+            if (Constants.LIST.equals(mode)) {
                 Bundle resultBundle =
                         locationHierarchyEndpointHelper.getPaginatedLocations(request);
                 resultContent = fhirR4JsonParser.encodeResourceToString(resultBundle);
@@ -56,14 +55,15 @@ public class LocationHierarchyEndpoint extends BaseEndpoint {
                         locationHierarchy.getId())) {
                     resultContent =
                             fhirR4JsonParser.encodeResourceToString(
-                                    createEmptyBundle(
+                                    Utils.createEmptyBundle(
                                             request.getRequestURL()
                                                     + "?"
                                                     + request.getQueryString()));
                 } else {
                     resultContent =
                             fhirR4JsonParser.encodeResourceToString(
-                                    createBundle(Collections.singletonList(locationHierarchy)));
+                                    Utils.createBundle(
+                                            Collections.singletonList(locationHierarchy)));
                 }
             }
             response.setContentType("application/json");

--- a/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/LocationHierarchyEndpoint.java
+++ b/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/LocationHierarchyEndpoint.java
@@ -46,8 +46,10 @@ public class LocationHierarchyEndpoint extends BaseEndpoint {
             String mode = request.getParameter(Constants.MODE);
             String resultContent;
             if (Objects.equals(mode, Constants.LIST)) {
+                Location parentLocation =
+                        locationHierarchyEndpointHelper.getLocationById(identifier);
                 List<Location> locations =
-                        locationHierarchyEndpointHelper.getDescendants(identifier);
+                        locationHierarchyEndpointHelper.getDescendants(identifier, parentLocation);
                 List<Resource> resourceLocations = new ArrayList<>(locations);
                 if (locations.isEmpty()) {
                     resultContent =

--- a/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/LocationHierarchyEndpointHelper.java
+++ b/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/LocationHierarchyEndpointHelper.java
@@ -4,12 +4,16 @@ import static org.smartregister.utils.Constants.LOCATION_RESOURCE;
 import static org.smartregister.utils.Constants.LOCATION_RESOURCE_NOT_FOUND;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.annotation.Nullable;
+import javax.servlet.http.HttpServletRequest;
 
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Location;
+import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.StringType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -110,5 +114,44 @@ public class LocationHierarchyEndpointHelper {
             logger.error(e.getMessage());
         }
         return location;
+    }
+
+    public Bundle getPaginatedLocations(HttpServletRequest request) {
+        String identifier = request.getParameter(Constants.IDENTIFIER);
+        String pageSize = request.getParameter(Constants.PAGINATION_PAGE_SIZE);
+        String pageNumber = request.getParameter(Constants.PAGINATION_PAGE_NUMBER);
+        Map<String, String[]> parameters = new HashMap<>(request.getParameterMap());
+
+        int count =
+                pageSize != null
+                        ? Integer.parseInt(pageSize)
+                        : Constants.PAGINATION_DEFAULT_PAGE_SIZE;
+        int page =
+                pageNumber != null
+                        ? Integer.parseInt(pageNumber)
+                        : Constants.PAGINATION_DEFAULT_PAGE_NUMBER;
+
+        int start = Math.max(0, (page - 1)) * count;
+        Location parentLocation = getLocationById(identifier);
+        List<Location> locations = getDescendants(identifier, parentLocation);
+        List<Resource> resourceLocations = new ArrayList<>(locations);
+        int totalEntries = locations.size();
+
+        int end = Math.min(start + count, resourceLocations.size());
+        List<Resource> paginatedResourceLocations = resourceLocations.subList(start, end);
+        Bundle resultBundle;
+
+        if (locations.isEmpty()) {
+            resultBundle =
+                    BaseEndpoint.createEmptyBundle(
+                            request.getRequestURL() + "?" + request.getQueryString());
+        } else {
+            resultBundle = BaseEndpoint.createBundle(paginatedResourceLocations);
+            StringBuilder urlBuilder = new StringBuilder(request.getRequestURL());
+            SyncAccessDecision.addPaginationLinks(
+                    urlBuilder, resultBundle, page, totalEntries, count, parameters);
+        }
+
+        return resultBundle;
     }
 }

--- a/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/LocationHierarchyEndpointHelper.java
+++ b/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/LocationHierarchyEndpointHelper.java
@@ -89,8 +89,7 @@ public class LocationHierarchyEndpointHelper {
             for (Bundle.BundleEntryComponent childLocation : childLocationBundle.getEntry()) {
                 Location childLocationEntity = (Location) childLocation.getResource();
                 allLocations.add(childLocationEntity);
-                allLocations.addAll(
-                        getDescendants(childLocationEntity.getIdElement().getIdPart()));
+                allLocations.addAll(getDescendants(childLocationEntity.getIdElement().getIdPart()));
             }
         }
 

--- a/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/LocationHierarchyEndpointHelper.java
+++ b/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/LocationHierarchyEndpointHelper.java
@@ -12,7 +12,6 @@ import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
 
 import org.hl7.fhir.r4.model.Bundle;
-import org.hl7.fhir.r4.model.DomainResource;
 import org.hl7.fhir.r4.model.Location;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.StringType;
@@ -77,18 +76,13 @@ public class LocationHierarchyEndpointHelper {
     private List<Location> getLocationHierarchyLocations(
             String locationId, Location parentLocation) {
         List<Location> descendants;
-        String flatLocation = Constants.FLAT_PREFIX + locationId;
 
         if (CacheHelper.INSTANCE.skipCache()) {
             descendants = getDescendants(locationId, parentLocation);
         } else {
             descendants =
-                    (List<Location>)
-                            CacheHelper.INSTANCE.resourceCache.get(
-                                    flatLocation,
-                                    key ->
-                                            (DomainResource)
-                                                    getDescendants(locationId, parentLocation));
+                    CacheHelper.INSTANCE.locationListCache.get(
+                            locationId, key -> getDescendants(locationId, parentLocation));
         }
         return descendants;
     }

--- a/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/LocationHierarchyEndpointHelper.java
+++ b/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/LocationHierarchyEndpointHelper.java
@@ -56,7 +56,7 @@ public class LocationHierarchyEndpointHelper {
         LocationHierarchy locationHierarchy = new LocationHierarchy();
         if (location != null) {
             logger.info("Building Location Hierarchy of Location Id : " + locationId);
-            locationHierarchyTree.buildTreeFromList(getDescendants(locationId));
+            locationHierarchyTree.buildTreeFromList(getDescendants(locationId, location));
             StringType locationIdString = new StringType().setId(locationId).getIdElement();
             locationHierarchy.setLocationId(locationIdString);
             locationHierarchy.setId(LOCATION_RESOURCE + locationId);
@@ -69,8 +69,11 @@ public class LocationHierarchyEndpointHelper {
         return locationHierarchy;
     }
 
-    public List<Location> getDescendants(String locationId) {
-        Location parentLocation = getLocationById(locationId);
+    private List<Location> getLocationHierarchy(String locationId, Location parentLocation) {
+        return getDescendants(locationId, parentLocation);
+    }
+
+    public List<Location> getDescendants(String locationId, Location parentLocation) {
 
         Bundle childLocationBundle =
                 getFhirClientForR4()
@@ -89,14 +92,15 @@ public class LocationHierarchyEndpointHelper {
             for (Bundle.BundleEntryComponent childLocation : childLocationBundle.getEntry()) {
                 Location childLocationEntity = (Location) childLocation.getResource();
                 allLocations.add(childLocationEntity);
-                allLocations.addAll(getDescendants(childLocationEntity.getIdElement().getIdPart()));
+                allLocations.addAll(
+                        getDescendants(childLocationEntity.getIdElement().getIdPart(), null));
             }
         }
 
         return allLocations;
     }
 
-    private @Nullable Location getLocationById(String locationId) {
+    public @Nullable Location getLocationById(String locationId) {
         Location location = null;
         try {
             location =

--- a/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/LocationHierarchyEndpointHelper.java
+++ b/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/LocationHierarchyEndpointHelper.java
@@ -73,7 +73,8 @@ public class LocationHierarchyEndpointHelper {
         return locationHierarchy;
     }
 
-    private List<Location> getLocationHierarchy(String locationId, Location parentLocation) {
+    private List<Location> getLocationHierarchyLocations(
+            String locationId, Location parentLocation) {
         return getDescendants(locationId, parentLocation);
     }
 
@@ -143,12 +144,12 @@ public class LocationHierarchyEndpointHelper {
 
         if (locations.isEmpty()) {
             resultBundle =
-                    BaseEndpoint.createEmptyBundle(
+                    Utils.createEmptyBundle(
                             request.getRequestURL() + "?" + request.getQueryString());
         } else {
-            resultBundle = BaseEndpoint.createBundle(paginatedResourceLocations);
+            resultBundle = Utils.createBundle(paginatedResourceLocations);
             StringBuilder urlBuilder = new StringBuilder(request.getRequestURL());
-            SyncAccessDecision.addPaginationLinks(
+            Utils.addPaginationLinks(
                     urlBuilder, resultBundle, page, totalEntries, count, parameters);
         }
 

--- a/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/PractitionerDetailEndpoint.java
+++ b/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/PractitionerDetailEndpoint.java
@@ -14,15 +14,11 @@ import org.smartregister.model.practitioner.PractitionerDetails;
 
 import com.google.fhir.gateway.TokenVerifier;
 
-import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.parser.IParser;
 import ca.uhn.fhir.rest.server.exceptions.AuthenticationException;
 
 @WebServlet("/PractitionerDetail")
 public class PractitionerDetailEndpoint extends BaseEndpoint {
     private final TokenVerifier tokenVerifier;
-    private final FhirContext fhirR4Context = FhirContext.forR4();
-    private final IParser fhirR4JsonParser = fhirR4Context.newJsonParser().setPrettyPrint(true);
     private final PractitionerDetailsEndpointHelper practitionerDetailsEndpointHelper;
 
     public PractitionerDetailEndpoint() throws IOException {

--- a/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/PractitionerDetailEndpoint.java
+++ b/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/PractitionerDetailEndpoint.java
@@ -47,12 +47,12 @@ public class PractitionerDetailEndpoint extends BaseEndpoint {
                     practitionerDetails.getId())) {
                 resultContent =
                         fhirR4JsonParser.encodeResourceToString(
-                                createEmptyBundle(
+                                Utils.createEmptyBundle(
                                         request.getRequestURL() + "?" + request.getQueryString()));
             } else {
                 resultContent =
                         fhirR4JsonParser.encodeResourceToString(
-                                createBundle(Collections.singletonList(practitionerDetails)));
+                                Utils.createBundle(Collections.singletonList(practitionerDetails)));
             }
 
             response.setContentType("application/json");

--- a/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/SyncAccessDecision.java
+++ b/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/SyncAccessDecision.java
@@ -364,12 +364,12 @@ public class SyncAccessDecision implements AccessDecision {
     }
 
     public static Bundle addPaginationLinks(
-        StringBuilder urlBuilder,
-        Bundle resultBundle,
-        int page,
-        int totalEntries,
-        int count,
-        Map<String, String[]> parameters) {
+            StringBuilder urlBuilder,
+            Bundle resultBundle,
+            int page,
+            int totalEntries,
+            int count,
+            Map<String, String[]> parameters) {
         resultBundle.setTotal(totalEntries);
 
         // add pagination links
@@ -486,7 +486,7 @@ public class SyncAccessDecision implements AccessDecision {
     }
 
     private static String constructUpdatedUrl(
-        StringBuilder urlBuilder, Map<String, String[]> parameters) {
+            StringBuilder urlBuilder, Map<String, String[]> parameters) {
         urlBuilder.append("?");
         for (Map.Entry<String, String[]> entry : parameters.entrySet()) {
             String paramName = entry.getKey();

--- a/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/SyncAccessDecision.java
+++ b/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/SyncAccessDecision.java
@@ -373,7 +373,7 @@ public class SyncAccessDecision implements AccessDecision {
         resultBundle.setTotal(totalEntries);
 
         // add pagination links
-        int nextPage = page < totalEntries / count ? page + 1 : 0; // 0 indicates no next page
+        int nextPage = page < ((float)totalEntries / count) ? page + 1 : 0; // 0 indicates no next page
         int prevPage = page > 1 ? page - 1 : 0; // 0 indicates no previous page
 
         Bundle.BundleLinkComponent selfLink = new Bundle.BundleLinkComponent();

--- a/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/SyncAccessDecision.java
+++ b/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/SyncAccessDecision.java
@@ -372,8 +372,8 @@ public class SyncAccessDecision implements AccessDecision {
             Map<String, String[]> parameters) {
         resultBundle.setTotal(totalEntries);
 
-        // add pagination links
-        int nextPage = page < ((float)totalEntries / count) ? page + 1 : 0; // 0 indicates no next page
+        int nextPage =
+                page < ((float) totalEntries / count) ? page + 1 : 0; // 0 indicates no next page
         int prevPage = page > 1 ? page - 1 : 0; // 0 indicates no previous page
 
         Bundle.BundleLinkComponent selfLink = new Bundle.BundleLinkComponent();

--- a/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/Utils.java
+++ b/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/Utils.java
@@ -70,6 +70,13 @@ public class Utils {
         return urlBuilder.toString();
     }
 
+    /**
+     * Creates a Bundle object containing a list of resources. This method set the total number of
+     * records in the resourceList
+     *
+     * @param resourceList The list of resources to include in the Bundle.
+     * @return A Bundle object containing the provided resources.
+     */
     public static Bundle createBundle(List<Resource> resourceList) {
         Bundle responseBundle = new Bundle();
         List<Bundle.BundleEntryComponent> bundleEntryComponentList = new ArrayList<>();

--- a/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/Utils.java
+++ b/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/Utils.java
@@ -1,0 +1,97 @@
+package org.smartregister.fhir.gateway.plugins;
+
+import java.util.*;
+
+import org.hl7.fhir.instance.model.api.IBaseBundle;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Resource;
+
+public class Utils {
+
+    public static Bundle addPaginationLinks(
+            StringBuilder urlBuilder,
+            Bundle resultBundle,
+            int page,
+            int totalEntries,
+            int count,
+            Map<String, String[]> parameters) {
+        resultBundle.setTotal(totalEntries);
+
+        int nextPage =
+                page < ((float) totalEntries / count) ? page + 1 : 0; // 0 indicates no next page
+        int prevPage = page > 1 ? page - 1 : 0; // 0 indicates no previous page
+
+        Bundle.BundleLinkComponent selfLink = new Bundle.BundleLinkComponent();
+        List<Bundle.BundleLinkComponent> link = new ArrayList<>();
+        String selfUrl = constructUpdatedUrl(new StringBuilder(urlBuilder), parameters);
+        selfLink.setRelation(IBaseBundle.LINK_SELF);
+        selfLink.setUrl(selfUrl);
+        link.add(selfLink);
+        resultBundle.setLink(link);
+
+        if (nextPage > 0) {
+            parameters.put(
+                    Constants.PAGINATION_PAGE_NUMBER, new String[] {String.valueOf(nextPage)});
+            String nextUrl = constructUpdatedUrl(new StringBuilder(urlBuilder), parameters);
+            Bundle.BundleLinkComponent nextLink = new Bundle.BundleLinkComponent();
+            nextLink.setRelation(IBaseBundle.LINK_NEXT);
+            nextLink.setUrl(nextUrl);
+            resultBundle.addLink(nextLink);
+        }
+        if (prevPage > 0) {
+            parameters.put(
+                    Constants.PAGINATION_PAGE_NUMBER, new String[] {String.valueOf(prevPage)});
+            String prevUrl = constructUpdatedUrl(new StringBuilder(urlBuilder), parameters);
+            Bundle.BundleLinkComponent previousLink = new Bundle.BundleLinkComponent();
+            previousLink.setRelation(IBaseBundle.LINK_PREV);
+            previousLink.setUrl(prevUrl);
+            resultBundle.addLink(previousLink);
+        }
+        return resultBundle;
+    }
+
+    private static String constructUpdatedUrl(
+            StringBuilder urlBuilder, Map<String, String[]> parameters) {
+        urlBuilder.append("?");
+        for (Map.Entry<String, String[]> entry : parameters.entrySet()) {
+            String paramName = entry.getKey();
+            String[] paramValues = entry.getValue();
+
+            for (String paramValue : paramValues) {
+                urlBuilder.append(paramName).append("=").append(paramValue).append("&");
+            }
+        }
+
+        // Remove the trailing '&' if present
+        if (urlBuilder.charAt(urlBuilder.length() - 1) == '&') {
+            urlBuilder.deleteCharAt(urlBuilder.length() - 1);
+        }
+
+        return urlBuilder.toString();
+    }
+
+    public static Bundle createBundle(List<Resource> resourceList) {
+        Bundle responseBundle = new Bundle();
+        List<Bundle.BundleEntryComponent> bundleEntryComponentList = new ArrayList<>();
+
+        for (Resource resource : resourceList) {
+            bundleEntryComponentList.add(new Bundle.BundleEntryComponent().setResource(resource));
+        }
+
+        responseBundle.setEntry(bundleEntryComponentList);
+        responseBundle.setTotal(bundleEntryComponentList.size());
+        return responseBundle;
+    }
+
+    public static Bundle createEmptyBundle(String requestURL) {
+        Bundle responseBundle = new Bundle();
+        responseBundle.setId(UUID.randomUUID().toString());
+        Bundle.BundleLinkComponent linkComponent = new Bundle.BundleLinkComponent();
+        linkComponent.setRelation(Bundle.LINK_SELF);
+        linkComponent.setUrl(requestURL);
+        responseBundle.setLink(Collections.singletonList(linkComponent));
+        responseBundle.setType(Bundle.BundleType.SEARCHSET);
+        responseBundle.setTotal(0);
+        return responseBundle;
+    }
+}

--- a/plugins/src/test/java/org/smartregister/fhir/gateway/plugins/LocationHierarchyEndpointHelperTest.java
+++ b/plugins/src/test/java/org/smartregister/fhir/gateway/plugins/LocationHierarchyEndpointHelperTest.java
@@ -103,8 +103,8 @@ public class LocationHierarchyEndpointHelperTest {
                 "http://test:8080/LocationHierarchy?identifier=12345&_page=2&_count=2",
                 resultBundle.getLink("self").getUrl());
         Assert.assertEquals(
-            "http://test:8080/LocationHierarchy?identifier=12345&_page=3&_count=2",
-            resultBundle.getLink("next").getUrl());
+                "http://test:8080/LocationHierarchy?identifier=12345&_page=3&_count=2",
+                resultBundle.getLink("next").getUrl());
     }
 
     private Bundle getLocationBundle() {

--- a/plugins/src/test/java/org/smartregister/fhir/gateway/plugins/LocationHierarchyEndpointHelperTest.java
+++ b/plugins/src/test/java/org/smartregister/fhir/gateway/plugins/LocationHierarchyEndpointHelperTest.java
@@ -95,13 +95,16 @@ public class LocationHierarchyEndpointHelperTest {
         Assert.assertTrue(resultBundle.hasLink());
         Assert.assertTrue(resultBundle.hasTotal());
         Assert.assertEquals(2, resultBundle.getEntry().size());
-        Assert.assertEquals(2, resultBundle.getLink().size());
+        Assert.assertEquals(3, resultBundle.getLink().size());
         Assert.assertEquals(
                 "http://test:8080/LocationHierarchy?identifier=12345&_page=1&_count=2",
                 resultBundle.getLink("previous").getUrl());
         Assert.assertEquals(
                 "http://test:8080/LocationHierarchy?identifier=12345&_page=2&_count=2",
                 resultBundle.getLink("self").getUrl());
+        Assert.assertEquals(
+            "http://test:8080/LocationHierarchy?identifier=12345&_page=3&_count=2",
+            resultBundle.getLink("next").getUrl());
     }
 
     private Bundle getLocationBundle() {

--- a/plugins/src/test/java/org/smartregister/fhir/gateway/plugins/LocationHierarchyEndpointHelperTest.java
+++ b/plugins/src/test/java/org/smartregister/fhir/gateway/plugins/LocationHierarchyEndpointHelperTest.java
@@ -5,11 +5,16 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
 
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.Location;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -55,6 +60,50 @@ public class LocationHierarchyEndpointHelperTest {
         assertEquals("Location Resource : 12345", locationHierarchy.getId());
     }
 
+    @Test
+    public void testGetPaginatedLocationsPaginatesLocations() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        Mockito.doReturn("12345").when(request).getParameter(Constants.IDENTIFIER);
+        Mockito.doReturn("2").when(request).getParameter(Constants.PAGINATION_PAGE_SIZE);
+        Mockito.doReturn("2").when(request).getParameter(Constants.PAGINATION_PAGE_NUMBER);
+        Mockito.doReturn(new StringBuffer("http://test:8080/LocationHierarchy"))
+                .when(request)
+                .getRequestURL();
+
+        Map<String, String[]> parameters = new HashMap<>();
+        // Populate the HashMap with the specified parameters
+        parameters.put(Constants.IDENTIFIER, new String[] {"12345"});
+        parameters.put(Constants.PAGINATION_PAGE_SIZE, new String[] {"2"});
+        parameters.put(Constants.PAGINATION_PAGE_NUMBER, new String[] {"2"});
+
+        Mockito.doReturn(parameters).when(request).getParameterMap();
+
+        LocationHierarchyEndpointHelper mockLocationHierarchyEndpointHelper =
+                mock(LocationHierarchyEndpointHelper.class);
+        List<Location> locations = createLocationList(5);
+
+        Mockito.doCallRealMethod()
+                .when(mockLocationHierarchyEndpointHelper)
+                .getPaginatedLocations(request);
+        Mockito.doReturn(locations)
+                .when(mockLocationHierarchyEndpointHelper)
+                .getDescendants("12345", null);
+
+        Bundle resultBundle = mockLocationHierarchyEndpointHelper.getPaginatedLocations(request);
+
+        Assert.assertTrue(resultBundle.hasEntry());
+        Assert.assertTrue(resultBundle.hasLink());
+        Assert.assertTrue(resultBundle.hasTotal());
+        Assert.assertEquals(2, resultBundle.getEntry().size());
+        Assert.assertEquals(2, resultBundle.getLink().size());
+        Assert.assertEquals(
+                "http://test:8080/LocationHierarchy?identifier=12345&_page=1&_count=2",
+                resultBundle.getLink("previous").getUrl());
+        Assert.assertEquals(
+                "http://test:8080/LocationHierarchy?identifier=12345&_page=2&_count=2",
+                resultBundle.getLink("self").getUrl());
+    }
+
     private Bundle getLocationBundle() {
         Bundle bundleLocation = new Bundle();
         bundleLocation.setId("Location/1234");
@@ -69,5 +118,16 @@ public class LocationHierarchyEndpointHelperTest {
         bundleEntryComponent.setResource(location);
         bundleLocation.addEntry(bundleEntryComponent);
         return bundleLocation;
+    }
+
+    private List<Location> createLocationList(int numLocations) {
+        // Create a list of locations
+        List<Location> locations = new ArrayList<>();
+        for (int i = 0; i < numLocations; i++) {
+            Location location = new Location();
+            location.setId(Integer.toString(i));
+            locations.add(location);
+        }
+        return locations;
     }
 }

--- a/plugins/src/test/java/org/smartregister/fhir/gateway/plugins/SyncAccessDecisionTest.java
+++ b/plugins/src/test/java/org/smartregister/fhir/gateway/plugins/SyncAccessDecisionTest.java
@@ -753,7 +753,7 @@ public class SyncAccessDecisionTest {
         // Verify returned result content from the server request has pagination links
         Assert.assertNotNull(resultContent);
         Assert.assertEquals(
-                "{\"resourceType\":\"Bundle\",\"id\":\"bundle-result-id\",\"type\":\"batch-response\",\"total\":1,\"link\":[{\"relation\":\"self\",\"url\":\"http://test:8080/fhir/List?_page=1&_count=1\"},{\"relation\":\"next\",\"url\":\"http://test:8080/fhir/List?_page=2&_count=1\"}]}",
+                "{\"resourceType\":\"Bundle\",\"id\":\"bundle-result-id\",\"type\":\"batch-response\",\"total\":2,\"link\":[{\"relation\":\"self\",\"url\":\"http://test:8080/fhir/List?_page=1&_count=1\"},{\"relation\":\"next\",\"url\":\"http://test:8080/fhir/List?_page=2&_count=1\"}]}",
                 resultContent);
     }
 
@@ -838,7 +838,7 @@ public class SyncAccessDecisionTest {
         // Verify returned result content from the server request, has pagination links
         Assert.assertNotNull(resultContent);
         Assert.assertEquals(
-                "{\"resourceType\":\"Bundle\",\"id\":\"bundle-result-id\",\"type\":\"batch-response\",\"total\":1,\"link\":[{\"relation\":\"self\",\"url\":\"http://test:8080/fhir/List?_page=2&_count=1\"},{\"relation\":\"previous\",\"url\":\"http://test:8080/fhir/List?_page=1&_count=1\"}]}",
+                "{\"resourceType\":\"Bundle\",\"id\":\"bundle-result-id\",\"type\":\"batch-response\",\"total\":2,\"link\":[{\"relation\":\"self\",\"url\":\"http://test:8080/fhir/List?_page=2&_count=1\"},{\"relation\":\"previous\",\"url\":\"http://test:8080/fhir/List?_page=1&_count=1\"}]}",
                 resultContent);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.smartregister</groupId>
   <artifactId>opensrp-gateway-plugin</artifactId>
-  <version>1.0.8</version>
+  <version>1.0.9</version>
   <packaging>pom</packaging>
 
   <modules>


### PR DESCRIPTION
Add option to return location hierarchy in a list instead of a tree depending on a parameter value



**IMPORTANT: Where possible all PRs must be linked to a Github issue**

fixes https://github.com/opensrp/fhircore/issues/3161
fixes https://github.com/onaio/fhir-gateway-extension/issues/45

**Engineer Checklist**

- [x] I have written **Unit tests** for any new feature(s) and edge cases for
      bug fixes
- [x] I have run `mvn spotless:check` to check my code follows the project's
      style guide
- [x] I have run `mvn clean test jacoco:report` to confirm the coverage report
      was generated at `plugins/target/site/jacoco/index.html`
- [x] I ran `mvn clean package` right before creating this pull request.
