### PR TITLE
Process different client requests uniquely. 

### DIFF
--- a/exec/pom.xml
+++ b/exec/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.smartregister</groupId>
     <artifactId>opensrp-gateway-plugin</artifactId>
-    <version>1.0.14</version>
+    <version>1.0.15</version>
   </parent>
 
   <artifactId>exec</artifactId>
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>org.smartregister</groupId>
       <artifactId>plugins</artifactId>
-      <version>1.0.14</version>
+      <version>1.0.15</version>
     </dependency>
 
     <dependency>

--- a/exec/pom.xml
+++ b/exec/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.smartregister</groupId>
     <artifactId>opensrp-gateway-plugin</artifactId>
-    <version>1.0.15</version>
+    <version>2.0.0</version>
   </parent>
 
   <artifactId>exec</artifactId>
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>org.smartregister</groupId>
       <artifactId>plugins</artifactId>
-      <version>1.0.15</version>
+      <version>2.0.0</version>
     </dependency>
 
     <dependency>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.smartregister</groupId>
     <artifactId>opensrp-gateway-plugin</artifactId>
-    <version>1.0.15</version>
+    <version>2.0.0</version>
   </parent>
 
   <artifactId>plugins</artifactId>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.smartregister</groupId>
     <artifactId>opensrp-gateway-plugin</artifactId>
-    <version>1.0.14</version>
+    <version>1.0.15</version>
   </parent>
 
   <artifactId>plugins</artifactId>

--- a/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/Constants.java
+++ b/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/Constants.java
@@ -27,6 +27,8 @@ public class Constants {
     public static final String DEFAULT_RELATED_ENTITY_TAG_URL =
             "https://smartregister.org/related-entity-location-tag-id";
     public static final String ROLE_ALL_LOCATIONS = "ALL_LOCATIONS";
+    public static final String ROLE_ANDROID_CLIENT = "ANDROID_CLIENT";
+    public static final String ROLE_WEB_CLIENT = "WEB_CLIENT";
     public static final String MODE = "mode";
     public static final String LIST = "list";
     public static final String CORS_ALLOW_HEADERS_KEY = "Access-Control-Allow-Headers";
@@ -37,6 +39,7 @@ public class Constants {
     public static final String CORS_ALLOW_ORIGIN_VALUE = "*";
     public static final String CORS_ALLOW_ORIGIN_ENV = "CORS_ALLOW_ORIGIN";
     public static final String UNDERSCORE = "_";
+    public static final String[] CLIENT_ROLES = {ROLE_WEB_CLIENT, ROLE_ANDROID_CLIENT};
 
     public interface Literals {
         String EQUALS = "=";

--- a/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/SyncAccessDecision.java
+++ b/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/SyncAccessDecision.java
@@ -94,9 +94,12 @@ public class SyncAccessDecision implements AccessDecision {
     public RequestMutation getRequestMutation(RequestDetailsReader requestDetailsReader) {
 
         RequestMutation requestMutation = null;
+        String clientRole = getClientRole();
+
+        // Check if it is the Sync URL and Skip app-wide
         if (isSyncUrl(requestDetailsReader)
-                && !shouldSkipDataFiltering(
-                        requestDetailsReader)) { // Check if it is the Sync URL and Skip app-wide
+                && !shouldSkipDataFiltering(requestDetailsReader)
+                && clientRole.equals(Constants.ROLE_ANDROID_CLIENT)) {
             // accessible resource requests
 
             if (syncStrategyIdsMap.isEmpty()
@@ -117,24 +120,17 @@ public class SyncAccessDecision implements AccessDecision {
                         forbiddenOperationException.getMessage(),
                         forbiddenOperationException);
             }
-
-            String clientRole = getClientRole();
-
-            if (clientRole.equals(Constants.ROLE_ANDROID_CLIENT)) {
-                List<String> syncFilterParameterValues =
-                        addSyncFilters(getSyncTags(this.syncStrategy, this.syncStrategyIdsMap));
-                requestMutation =
-                        RequestMutation.builder()
-                                .queryParams(
-                                        Map.of(
-                                                Constants.TAG_SEARCH_PARAM,
-                                                List.of(
-                                                        StringUtils.join(
-                                                                syncFilterParameterValues, ","))))
-                                .build();
-            } else if (clientRole.equals(Constants.ROLE_WEB_CLIENT)) {
-                requestMutation = RequestMutation.builder().build();
-            }
+            List<String> syncFilterParameterValues =
+                    addSyncFilters(getSyncTags(this.syncStrategy, this.syncStrategyIdsMap));
+            requestMutation =
+                    RequestMutation.builder()
+                            .queryParams(
+                                    Map.of(
+                                            Constants.TAG_SEARCH_PARAM,
+                                            List.of(
+                                                    StringUtils.join(
+                                                            syncFilterParameterValues, ","))))
+                            .build();
         }
 
         return requestMutation;

--- a/plugins/src/test/java/org/smartregister/fhir/gateway/plugins/SyncAccessDecisionTest.java
+++ b/plugins/src/test/java/org/smartregister/fhir/gateway/plugins/SyncAccessDecisionTest.java
@@ -971,6 +971,7 @@ public class SyncAccessDecisionTest {
 
     @Test
     public void preProcessWhenRequestIsAnOperationRequestShouldAddFilters() {
+        userRoles.add(Constants.ROLE_ANDROID_CLIENT);
         locationIds.add("locationid12");
         locationIds.add("locationid2");
         testInstance = createSyncAccessDecisionTestInstance(Constants.SyncStrategy.LOCATION);

--- a/plugins/src/test/java/org/smartregister/fhir/gateway/plugins/SyncAccessDecisionTest.java
+++ b/plugins/src/test/java/org/smartregister/fhir/gateway/plugins/SyncAccessDecisionTest.java
@@ -59,6 +59,7 @@ public class SyncAccessDecisionTest {
     @Test
     public void preProcessShouldAddLocationIdFiltersWhenUserIsAssignedToLocationsOnly()
             throws IOException {
+        userRoles.add(Constants.ROLE_ANDROID_CLIENT);
         locationIds.add("locationid12");
         locationIds.add("locationid2");
         testInstance = createSyncAccessDecisionTestInstance(Constants.SyncStrategy.LOCATION);
@@ -97,9 +98,57 @@ public class SyncAccessDecisionTest {
     }
 
     @Test
+    public void preProcessWhenNotOneClientRoleIsAddedShouldThrowError() throws IOException {
+        // More than one
+        userRoles.add(Constants.ROLE_ANDROID_CLIENT);
+        userRoles.add(Constants.ROLE_WEB_CLIENT);
+        locationIds.add("locationid12");
+        locationIds.add("locationid2");
+        testInstance = createSyncAccessDecisionTestInstance(Constants.SyncStrategy.LOCATION);
+
+        RequestDetails requestDetails = new ServletRequestDetails();
+        requestDetails.setRequestType(RequestTypeEnum.GET);
+        requestDetails.setRestOperationType(RestOperationTypeEnum.SEARCH_TYPE);
+        requestDetails.setResourceName("Patient");
+        requestDetails.setFhirServerBase("https://smartregister.org/fhir");
+        requestDetails.setCompleteUrl("https://smartregister.org/fhir/Patient");
+        requestDetails.setRequestPath("Patient");
+
+        RuntimeException firstException =
+                Assert.assertThrows(
+                        RuntimeException.class,
+                        () -> {
+                            testInstance.getRequestMutation(
+                                    new TestRequestDetailsToReader(requestDetails));
+                        });
+
+        Assert.assertTrue(
+                firstException
+                        .getMessage()
+                        .contains("User must have only one of these client roles"));
+
+        // less than one
+        userRoles.remove(Constants.ROLE_ANDROID_CLIENT);
+        userRoles.remove(Constants.ROLE_WEB_CLIENT);
+        RuntimeException secondException =
+                Assert.assertThrows(
+                        RuntimeException.class,
+                        () -> {
+                            testInstance.getRequestMutation(
+                                    new TestRequestDetailsToReader(requestDetails));
+                        });
+
+        Assert.assertTrue(
+                secondException
+                        .getMessage()
+                        .contains("User must have only one of these client roles"));
+    }
+
+    @Test
     public void
             requestMutationWhenUserIsAssignedToRelatedEntityLocationIdsShouldAddAssignedRelatedEntityLocationIdsFilters()
                     throws IOException {
+        userRoles.add(Constants.ROLE_ANDROID_CLIENT);
         relatedEntityLocationIds.add("relocationid12");
         relatedEntityLocationIds.add("relocationid2");
         testInstance =
@@ -145,6 +194,7 @@ public class SyncAccessDecisionTest {
                     throws IOException {
         try (MockedStatic<PractitionerDetailsEndpointHelper> mockPractitionerDetailsEndpointHelper =
                 Mockito.mockStatic(PractitionerDetailsEndpointHelper.class)) {
+            userRoles.add(Constants.ROLE_ANDROID_CLIENT);
             List<String> selectedRelatedEntityLocationIds = new ArrayList<>();
             String srelocationid1 = "srelocationid1";
             String srelocationid2 = "srelocationid2";
@@ -215,6 +265,7 @@ public class SyncAccessDecisionTest {
     public void requestMutationWhenLocationUuidAreEmptyShouldNotError() throws IOException {
         try (MockedStatic<PractitionerDetailsEndpointHelper> mockPractitionerDetailsEndpointHelper =
                 Mockito.mockStatic(PractitionerDetailsEndpointHelper.class)) {
+            userRoles.add(Constants.ROLE_ANDROID_CLIENT);
             List<String> selectedRelatedEntityLocationIds = new ArrayList<>();
             String srelocationid1 = "";
             String srelocationid2 = " ";
@@ -276,6 +327,7 @@ public class SyncAccessDecisionTest {
     @Test
     public void preProcessShouldAddCareTeamIdFiltersWhenUserIsAssignedToCareTeamsOnly()
             throws IOException {
+        userRoles.add(Constants.ROLE_ANDROID_CLIENT);
         careTeamIds.add("careteamid1");
         careTeamIds.add("careteamid2");
         testInstance = createSyncAccessDecisionTestInstance(Constants.SyncStrategy.CARE_TEAM);
@@ -317,6 +369,7 @@ public class SyncAccessDecisionTest {
     @Test
     public void preProcessShouldAddOrganisationIdFiltersWhenUserIsAssignedToOrganisationsOnly()
             throws IOException {
+        userRoles.add(Constants.ROLE_ANDROID_CLIENT);
         organisationIds.add("organizationid1");
         organisationIds.add("organizationid2");
         testInstance = createSyncAccessDecisionTestInstance(Constants.SyncStrategy.ORGANIZATION);
@@ -353,6 +406,7 @@ public class SyncAccessDecisionTest {
 
     @Test
     public void preProcessShouldAddFiltersWhenResourceNotInSyncFilterIgnoredResourcesFile() {
+        userRoles.add(Constants.ROLE_ANDROID_CLIENT);
         organisationIds.add("organizationid1");
         organisationIds.add("organizationid2");
         testInstance = createSyncAccessDecisionTestInstance(Constants.SyncStrategy.ORGANIZATION);
@@ -388,6 +442,7 @@ public class SyncAccessDecisionTest {
 
     @Test
     public void preProcessShouldSkipAddingFiltersWhenResourceInSyncFilterIgnoredResourcesFile() {
+        userRoles.add(Constants.ROLE_ANDROID_CLIENT);
         organisationIds.add("organizationid1");
         organisationIds.add("organizationid2");
         testInstance = createSyncAccessDecisionTestInstance(Constants.SyncStrategy.ORGANIZATION);
@@ -413,6 +468,7 @@ public class SyncAccessDecisionTest {
     @Test
     public void
             preProcessShouldSkipAddingFiltersWhenSearchResourceByIdsInSyncFilterIgnoredResourcesFile() {
+        userRoles.add(Constants.ROLE_ANDROID_CLIENT);
         organisationIds.add("organizationid1");
         organisationIds.add("organizationid2");
         testInstance = createSyncAccessDecisionTestInstance(Constants.SyncStrategy.ORGANIZATION);
@@ -449,6 +505,7 @@ public class SyncAccessDecisionTest {
     @Test
     public void
             preProcessShouldAddFiltersWhenSearchResourceByIdsDoNotMatchSyncFilterIgnoredResources() {
+        userRoles.add(Constants.ROLE_ANDROID_CLIENT);
         organisationIds.add("organizationid1");
         organisationIds.add("organizationid2");
         testInstance = createSyncAccessDecisionTestInstance(Constants.SyncStrategy.ORGANIZATION);
@@ -496,6 +553,7 @@ public class SyncAccessDecisionTest {
 
     @Test(expected = RuntimeException.class)
     public void preprocessShouldThrowRuntimeExceptionWhenNoSyncStrategyFilterIsProvided() {
+        userRoles.add(Constants.ROLE_ANDROID_CLIENT);
         testInstance = createSyncAccessDecisionTestInstance(null);
 
         RequestDetails requestDetails = new ServletRequestDetails();

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.smartregister</groupId>
   <artifactId>opensrp-gateway-plugin</artifactId>
-  <version>1.0.15</version>
+  <version>2.0.0</version>
   <packaging>pom</packaging>
 
   <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.smartregister</groupId>
   <artifactId>opensrp-gateway-plugin</artifactId>
-  <version>1.0.14</version>
+  <version>1.0.15</version>
   <packaging>pom</packaging>
 
   <modules>


### PR DESCRIPTION
 Identify client using keycloak roles
 Process different client requests differently
 fixes https://github.com/onaio/fhir-gateway-extension/issues/50

**IMPORTANT: Where possible all PRs must be linked to a Github issue**

Resolves [link to issue]

**Engineer Checklist**

- [x] I have written **Unit tests** for any new feature(s) and edge cases for
      bug fixes
- [x] I have added documentation for any new feature(s) and configuration
      option(s) on the `README.md`
- [x] I have run `mvn spotless:check` to check my code follows the project's
      style guide
- [x] I have run `mvn clean test jacoco:report` to confirm the coverage report
      was generated at `plugins/target/site/jacoco/index.html`
- [x] I ran `mvn clean package` right before creating this pull request.
