### PR TITLE
Admin level filtering after fetch

### DIFF
--- a/exec/pom.xml
+++ b/exec/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.smartregister</groupId>
     <artifactId>opensrp-gateway-plugin</artifactId>
-    <version>2.0.3</version>
+    <version>2.0.4</version>
   </parent>
 
   <artifactId>exec</artifactId>
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>org.smartregister</groupId>
       <artifactId>plugins</artifactId>
-      <version>2.0.3</version>
+      <version>2.0.4</version>
     </dependency>
 
     <dependency>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.smartregister</groupId>
     <artifactId>opensrp-gateway-plugin</artifactId>
-    <version>2.0.3</version>
+    <version>2.0.4</version>
   </parent>
 
   <artifactId>plugins</artifactId>

--- a/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/Constants.java
+++ b/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/Constants.java
@@ -24,6 +24,7 @@ public class Constants {
     public static final String MIN_ADMIN_LEVEL = "administrativeLevelMin";
     public static final String MAX_ADMIN_LEVEL = "administrativeLevelMax";
     public static final int DEFAULT_MAX_ADMIN_LEVEL = 10;
+    public static final int DEFAULT_MIN_ADMIN_LEVEL = 0;
     public static final String PAGINATION_PAGE_SIZE = "_count";
     public static final String PAGINATION_PAGE_NUMBER = "_page";
     public static final int PAGINATION_DEFAULT_PAGE_SIZE = 20;

--- a/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/PractitionerDetailsEndpointHelper.java
+++ b/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/PractitionerDetailsEndpointHelper.java
@@ -575,7 +575,8 @@ public class PractitionerDetailsEndpointHelper {
         LocationHierarchy locationHierarchy;
         for (String locationsIdentifier : locationsIdentifiers) {
             locationHierarchy =
-                    locationHierarchyEndpointHelper.getLocationHierarchy(locationsIdentifier, null);
+                    locationHierarchyEndpointHelper.getLocationHierarchy(
+                            locationsIdentifier, null, null);
             if (!org.smartregister.utils.Constants.LOCATION_RESOURCE_NOT_FOUND.equals(
                     locationHierarchy.getId())) locationHierarchyList.add(locationHierarchy);
         }

--- a/plugins/src/test/java/org/smartregister/fhir/gateway/plugins/LocationHierarchyEndpointHelperTest.java
+++ b/plugins/src/test/java/org/smartregister/fhir/gateway/plugins/LocationHierarchyEndpointHelperTest.java
@@ -285,6 +285,20 @@ public class LocationHierarchyEndpointHelperTest {
         verify(queryMock, times(2)).execute();
     }
 
+    @Test
+    public void testFilterLocationsByAdminLevelsBasic() {
+        List<Location> locations = createLocationList(5, true);
+        List<String> adminLevels = List.of("1", "3");
+
+        List<Location> filteredLocations =
+                locationHierarchyEndpointHelper.filterLocationsByAdminLevels(
+                        locations, adminLevels);
+
+        Assert.assertEquals(2, filteredLocations.size());
+        Assert.assertEquals("1", filteredLocations.get(0).getId());
+        Assert.assertEquals("3", filteredLocations.get(1).getId());
+    }
+
     private Bundle getLocationBundle() {
         Bundle bundleLocation = new Bundle();
         bundleLocation.setId("Location/1234");

--- a/plugins/src/test/java/org/smartregister/fhir/gateway/plugins/LocationHierarchyEndpointHelperTest.java
+++ b/plugins/src/test/java/org/smartregister/fhir/gateway/plugins/LocationHierarchyEndpointHelperTest.java
@@ -54,7 +54,7 @@ public class LocationHierarchyEndpointHelperTest {
                 .when(client)
                 .fetchResourceFromUrl(any(), any());
         LocationHierarchy locationHierarchy =
-                locationHierarchyEndpointHelper.getLocationHierarchy("non-existent", null);
+                locationHierarchyEndpointHelper.getLocationHierarchy("non-existent", null, null);
         assertEquals(
                 org.smartregister.utils.Constants.LOCATION_RESOURCE_NOT_FOUND,
                 locationHierarchy.getId());
@@ -69,7 +69,7 @@ public class LocationHierarchyEndpointHelperTest {
                 .when(client)
                 .fetchResourceFromUrl(Location.class, "Location/12345");
         LocationHierarchy locationHierarchy =
-                locationHierarchyEndpointHelper.getLocationHierarchy("12345", null);
+                locationHierarchyEndpointHelper.getLocationHierarchy("12345", null, null);
         assertEquals("Location Resource : 12345", locationHierarchy.getId());
     }
 
@@ -100,9 +100,12 @@ public class LocationHierarchyEndpointHelperTest {
         Mockito.doCallRealMethod()
                 .when(mockLocationHierarchyEndpointHelper)
                 .getPaginatedLocations(request, locationIds);
+        Mockito.doCallRealMethod()
+                .when(mockLocationHierarchyEndpointHelper)
+                .filterLocationsByAdminLevels(locations, adminLevels);
         Mockito.doReturn(locations)
                 .when(mockLocationHierarchyEndpointHelper)
-                .getDescendants("12345", null, adminLevels);
+                .getLocationHierarchyLocations("12345", null, adminLevels, adminLevels);
 
         Bundle resultBundle =
                 mockLocationHierarchyEndpointHelper.getPaginatedLocations(request, locationIds);
@@ -144,6 +147,7 @@ public class LocationHierarchyEndpointHelperTest {
                 .getRequestURL();
 
         Map<String, String[]> parameters = new HashMap<>();
+
         parameters.put(Constants.MODE, new String[] {"list"});
         parameters.put(Constants.SYNC_LOCATIONS, new String[] {"1,2,3,4"});
         LocationHierarchyEndpointHelper mockLocationHierarchyEndpointHelper =
@@ -152,6 +156,7 @@ public class LocationHierarchyEndpointHelperTest {
                 mock(PractitionerDetailsEndpointHelper.class);
         DecodedJWT mockDecodedJWT = mock(DecodedJWT.class);
         MockedStatic<JwtUtils> mockJwtUtils = Mockito.mockStatic(JwtUtils.class);
+        List<String> adminLevels = new ArrayList<>();
 
         List<Location> locations = createLocationList(4, false);
         List<String> locationIds = List.of("1", "2", "3", "4");
@@ -168,9 +173,13 @@ public class LocationHierarchyEndpointHelperTest {
                 .when(mockLocationHierarchyEndpointHelper)
                 .handleNonIdentifierRequest(
                         request, mockPractitionerDetailsEndpointHelper, mockDecodedJWT);
+        Mockito.doCallRealMethod()
+                .when(mockLocationHierarchyEndpointHelper)
+                .filterLocationsByAdminLevels(locations, adminLevels);
         Mockito.doReturn(locations)
                 .when(mockLocationHierarchyEndpointHelper)
-                .getDescendants(Mockito.anyString(), Mockito.any(), Mockito.any());
+                .getLocationHierarchyLocations(
+                        Mockito.anyString(), Mockito.any(), Mockito.any(), Mockito.any());
         Mockito.doReturn(Constants.SyncStrategy.RELATED_ENTITY_LOCATION)
                 .when(mockLocationHierarchyEndpointHelper)
                 .getSyncStrategyByAppId(Mockito.any());
@@ -232,7 +241,7 @@ public class LocationHierarchyEndpointHelperTest {
     }
 
     @Test
-    public void testGetDecendantsWithAdminLevelFiltersReturnsLocationsWithinAdminLevel() {
+    public void testGetDescendantsWithAdminLevelFiltersReturnsLocationsWithinAdminLevel() {
         String locationId = "12345";
         Location parentLocation = new Location();
         parentLocation.setId(locationId);

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.smartregister</groupId>
   <artifactId>opensrp-gateway-plugin</artifactId>
-  <version>2.0.3</version>
+  <version>2.0.4</version>
   <packaging>pom</packaging>
 
   <modules>


### PR DESCRIPTION
Move admin level filtering to be handled after fetching the locations
 fixes #75

**IMPORTANT: Where possible all PRs must be linked to a Github issue**

Resolves [link to issue]

**Engineer Checklist**

- [x] I have written **Unit tests** for any new feature(s) and edge cases for
      bug fixes
- [ ] I have added documentation for any new feature(s) and configuration
      option(s) on the `README.md`
- [x] I have run `mvn spotless:check` to check my code follows the project's
      style guide
- [x] I have run `mvn clean test jacoco:report` to confirm the coverage report
      was generated at `plugins/target/site/jacoco/index.html`
- [x] I ran `mvn clean package` right before creating this pull request.
