### PR TITLE
Optimize location hierarchy

### DIFF
--- a/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/CacheHelper.java
+++ b/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/CacheHelper.java
@@ -21,6 +21,8 @@ public enum CacheHelper {
 
     Cache<String, String> stringCache;
 
+    Cache<String, List<String>> listStringCache;
+
     CacheHelper() {
         cache =
                 Caffeine.newBuilder()
@@ -38,6 +40,11 @@ public enum CacheHelper {
                         .maximumSize(DEFAULT_CACHE_SIZE)
                         .build();
         stringCache =
+                Caffeine.newBuilder()
+                        .expireAfterWrite(getCacheExpiryDurationInSeconds(), TimeUnit.SECONDS)
+                        .maximumSize(DEFAULT_CACHE_SIZE)
+                        .build();
+        listStringCache =
                 Caffeine.newBuilder()
                         .expireAfterWrite(getCacheExpiryDurationInSeconds(), TimeUnit.SECONDS)
                         .maximumSize(DEFAULT_CACHE_SIZE)

--- a/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/LocationHierarchyEndpointHelper.java
+++ b/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/LocationHierarchyEndpointHelper.java
@@ -6,10 +6,8 @@ import static org.smartregister.utils.Constants.LOCATION_RESOURCE_NOT_FOUND;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
@@ -86,9 +84,8 @@ public class LocationHierarchyEndpointHelper {
             List<String> preFetchAdminLevels,
             List<String> postFetchAdminLevels,
             Boolean filterInventory) {
-        Set<String> uniqueLocationIds = new HashSet<>(locationIds);
 
-        return uniqueLocationIds.parallelStream()
+        return locationIds.parallelStream()
                 .map(
                         locationId ->
                                 getLocationHierarchy(
@@ -358,7 +355,6 @@ public class LocationHierarchyEndpointHelper {
         List<String> postFetchAdminLevels =
                 generateAdminLevels(administrativeLevelMin, administrativeLevelMax);
         Map<String, String[]> parameters = new HashMap<>(request.getParameterMap());
-        Set<String> uniqueLocationIds = new HashSet<>(locationIds);
 
         int count =
                 pageSize != null
@@ -372,7 +368,7 @@ public class LocationHierarchyEndpointHelper {
         int start = Math.max(0, (page - 1)) * count;
 
         List<Resource> resourceLocations =
-                uniqueLocationIds.parallelStream()
+                locationIds.parallelStream()
                         .flatMap(
                                 identifier ->
                                         getLocationHierarchyLocations(

--- a/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/LocationHierarchyEndpointHelper.java
+++ b/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/LocationHierarchyEndpointHelper.java
@@ -259,15 +259,9 @@ public class LocationHierarchyEndpointHelper {
                 return getPaginatedLocations(request, selectedSyncLocations);
 
             } else {
-                List<Location> locations =
-                        practitionerDetailsEndpointHelper
-                                .getPractitionerDetailsByKeycloakId(practitionerId)
-                                .getFhirPractitionerDetails()
-                                .getLocations();
-                List<String> locationIds = new ArrayList<>();
-                for (Location location : locations) {
-                    locationIds.add(location.getIdElement().getIdPart());
-                }
+                List<String> locationIds =
+                        practitionerDetailsEndpointHelper.getPractitionerLocationIdsByByKeycloakId(
+                                practitionerId);
                 return getPaginatedLocations(request, locationIds);
             }
 
@@ -287,11 +281,15 @@ public class LocationHierarchyEndpointHelper {
                                 .collect(Collectors.toList());
                 return Utils.createBundle(resourceList);
             } else {
+                List<String> locationIds =
+                        practitionerDetailsEndpointHelper.getPractitionerLocationIdsByByKeycloakId(
+                                practitionerId);
                 List<LocationHierarchy> locationHierarchies =
-                        practitionerDetailsEndpointHelper
-                                .getPractitionerDetailsByKeycloakId(practitionerId)
-                                .getFhirPractitionerDetails()
-                                .getLocationHierarchyList();
+                        getLocationHierarchies(
+                                locationIds,
+                                preFetchAdminLevels,
+                                postFetchAdminLevels,
+                                filterInventory);
                 List<Resource> resourceList =
                         locationHierarchies.stream()
                                 .map(locationHierarchy -> (Resource) locationHierarchy)

--- a/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/LocationHierarchyEndpointHelper.java
+++ b/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/LocationHierarchyEndpointHelper.java
@@ -443,7 +443,7 @@ public class LocationHierarchyEndpointHelper {
 
     public List<Location> filterLocationsByAdminLevels(
             List<Location> locations, List<String> postFetchAdminLevels) {
-        if (postFetchAdminLevels == null) {
+        if (postFetchAdminLevels == null || postFetchAdminLevels.isEmpty()) {
             return locations;
         }
         List<Location> allLocations = new ArrayList<>();

--- a/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/LocationHierarchyEndpointHelper.java
+++ b/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/LocationHierarchyEndpointHelper.java
@@ -113,7 +113,7 @@ public class LocationHierarchyEndpointHelper {
         if (location != null) {
             logger.info("Building Location Hierarchy of Location Id : {}", locationId);
 
-            List<Location> descendants = getDescendants(locationId, preFetchAdminLevels, location);
+            List<Location> descendants = getDescendants(locationId, location, preFetchAdminLevels);
             if (filterInventory) {
                 descendants = filterLocationsByInventory(descendants);
             }
@@ -140,12 +140,12 @@ public class LocationHierarchyEndpointHelper {
         List<Location> descendants;
 
         if (CacheHelper.INSTANCE.skipCache()) {
-            descendants = getDescendants(locationId, preFetchAdminLevels, parentLocation);
+            descendants = getDescendants(locationId, parentLocation, preFetchAdminLevels);
         } else {
             descendants =
                     CacheHelper.INSTANCE.locationListCache.get(
                             locationId,
-                            key -> getDescendants(locationId, preFetchAdminLevels, parentLocation));
+                            key -> getDescendants(locationId, parentLocation, preFetchAdminLevels));
         }
         if (filterInventory) {
             descendants = filterLocationsByInventory(descendants);
@@ -154,7 +154,7 @@ public class LocationHierarchyEndpointHelper {
     }
 
     public List<Location> getDescendants(
-            String locationId, List<String> adminLevels, Location parentLocation) {
+            String locationId, Location parentLocation, List<String> adminLevels) {
         IQuery<IBaseBundle> query =
                 getFhirClientForR4()
                         .search()

--- a/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/PractitionerDetailsEndpointHelper.java
+++ b/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/PractitionerDetailsEndpointHelper.java
@@ -275,7 +275,8 @@ public class PractitionerDetailsEndpointHelper {
         return locationIds;
     }
 
-    public List<String> getPractitionerLocationIdsByByKeycloakIdCore(String practitionerId) {
+    @VisibleForTesting
+    protected List<String> getPractitionerLocationIdsByByKeycloakIdCore(String practitionerId) {
 
         logger.info("Searching for CareTeams with Practitioner Id: " + practitionerId);
         Bundle careTeams = getCareTeams(practitionerId);
@@ -430,12 +431,14 @@ public class PractitionerDetailsEndpointHelper {
         return t -> seen.add(uniqueKeyExtractor.apply(t));
     }
 
-    private List<PractitionerRole> getPractitionerRolesByPractitionerId(String practitionerId) {
+    @VisibleForTesting
+    protected List<PractitionerRole> getPractitionerRolesByPractitionerId(String practitionerId) {
         Bundle practitionerRoles = getPractitionerRoles(practitionerId);
         return mapBundleToPractitionerRolesWithOrganization(practitionerRoles);
     }
 
-    private Set<String> getOrganizationIdsByPractitionerRoles(
+    @VisibleForTesting
+    protected Set<String> getOrganizationIdsByPractitionerRoles(
             List<PractitionerRole> practitionerRoles) {
         return practitionerRoles.stream()
                 .filter(PractitionerRole::hasOrganization)
@@ -490,7 +493,8 @@ public class PractitionerDetailsEndpointHelper {
                 .collect(Collectors.toList());
     }
 
-    private Bundle getCareTeams(String practitionerId) {
+    @VisibleForTesting
+    protected Bundle getCareTeams(String practitionerId) {
         return getFhirClientForR4()
                 .search()
                 .forResource(CareTeam.class)
@@ -607,7 +611,8 @@ public class PractitionerDetailsEndpointHelper {
                 .collect(Collectors.toSet());
     }
 
-    private List<CareTeam> mapBundleToCareTeams(Bundle careTeams) {
+    @VisibleForTesting
+    protected List<CareTeam> mapBundleToCareTeams(Bundle careTeams) {
         return careTeams != null
                 ? careTeams.getEntry().stream()
                         .map(bundleEntryComponent -> (CareTeam) bundleEntryComponent.getResource())
@@ -632,7 +637,8 @@ public class PractitionerDetailsEndpointHelper {
                 : Collections.emptyList();
     }
 
-    private List<OrganizationAffiliation> mapBundleToOrganizationAffiliation(
+    @VisibleForTesting
+    protected List<OrganizationAffiliation> mapBundleToOrganizationAffiliation(
             Bundle organizationAffiliationBundle) {
         return organizationAffiliationBundle != null
                 ? organizationAffiliationBundle.getEntry().stream()

--- a/plugins/src/test/java/org/smartregister/fhir/gateway/plugins/LocationHierarchyEndpointHelperTest.java
+++ b/plugins/src/test/java/org/smartregister/fhir/gateway/plugins/LocationHierarchyEndpointHelperTest.java
@@ -283,7 +283,7 @@ public class LocationHierarchyEndpointHelperTest {
 
         List<Location> descendants =
                 locationHierarchyEndpointHelper.getDescendants(
-                        locationId, adminLevels, parentLocation);
+                        locationId, parentLocation, adminLevels);
 
         Assert.assertNotNull(descendants);
         Assert.assertEquals(2, descendants.size());

--- a/plugins/src/test/java/org/smartregister/fhir/gateway/plugins/LocationHierarchyEndpointHelperTest.java
+++ b/plugins/src/test/java/org/smartregister/fhir/gateway/plugins/LocationHierarchyEndpointHelperTest.java
@@ -279,12 +279,11 @@ public class LocationHierarchyEndpointHelperTest {
         Mockito.doReturn(queryMock).when(queryMock).and(any(ICriterion.class));
         Mockito.doReturn(queryMock).when(queryMock).usingStyle(SearchStyleEnum.POST);
         Mockito.doReturn(queryMock).when(queryMock).returnBundle(Bundle.class);
-
         Mockito.doReturn(firstBundleMock, secondBundleMock).when(queryMock).execute();
 
         List<Location> descendants =
                 locationHierarchyEndpointHelper.getDescendants(
-                        locationId, parentLocation, adminLevels);
+                        locationId, adminLevels, parentLocation);
 
         Assert.assertNotNull(descendants);
         Assert.assertEquals(2, descendants.size());

--- a/plugins/src/test/java/org/smartregister/fhir/gateway/plugins/PractitionerDetailsEndpointHelperTest.java
+++ b/plugins/src/test/java/org/smartregister/fhir/gateway/plugins/PractitionerDetailsEndpointHelperTest.java
@@ -20,6 +20,7 @@ import org.hl7.fhir.r4.model.Location;
 import org.hl7.fhir.r4.model.Organization;
 import org.hl7.fhir.r4.model.OrganizationAffiliation;
 import org.hl7.fhir.r4.model.Practitioner;
+import org.hl7.fhir.r4.model.PractitionerRole;
 import org.hl7.fhir.r4.model.Reference;
 import org.junit.Assert;
 import org.junit.Before;
@@ -515,6 +516,71 @@ public class PractitionerDetailsEndpointHelperTest {
         Assert.assertEquals("2", result.get(1));
     }
 
+    @Test
+    public void testGetPractitionerLocationIdsByByKeycloakIdCoreReturnsLocationIds() {
+        String practitionerId = "keycloak-uuid-1234-1234";
+        Bundle careTeamBundle = getPractitionerBundle();
+        List<CareTeam> careTeamList = new ArrayList<>();
+        careTeamList.add(getCareTeam());
+        Set<String> careTeamManagingOrganizationIds = new HashSet<>();
+        careTeamManagingOrganizationIds.add("Organization/1234");
+
+        List<PractitionerRole> practitionerRoleList = getPractitionerRoleList();
+        Set<String> practitionerOrganizationIds = new HashSet<>();
+        practitionerOrganizationIds.add("Organization/5678");
+
+        Set<String> combinedOrganizationIds = new HashSet<>();
+        combinedOrganizationIds.addAll(careTeamManagingOrganizationIds);
+        combinedOrganizationIds.addAll(practitionerOrganizationIds);
+
+        Bundle organizationAffiliationsBundle = getOrganizationAffiliationsBundle();
+        List<OrganizationAffiliation> organizationAffiliations = new ArrayList<>();
+
+        organizationAffiliations.add(getOrganizationAffiliation());
+
+        List<String> locationIds = new ArrayList<>();
+        locationIds.add("Location/1234");
+
+        PractitionerDetailsEndpointHelper mockPractitionerDetailsEndpointHelper =
+                mock(PractitionerDetailsEndpointHelper.class);
+
+        Mockito.doReturn(careTeamBundle)
+                .when(mockPractitionerDetailsEndpointHelper)
+                .getCareTeams(practitionerId);
+        Mockito.doReturn(careTeamList)
+                .when(mockPractitionerDetailsEndpointHelper)
+                .mapBundleToCareTeams(careTeamBundle);
+        Mockito.doReturn(careTeamManagingOrganizationIds)
+                .when(mockPractitionerDetailsEndpointHelper)
+                .getManagingOrganizationsOfCareTeamIds(careTeamList);
+        Mockito.doReturn(practitionerRoleList)
+                .when(mockPractitionerDetailsEndpointHelper)
+                .getPractitionerRolesByPractitionerId(practitionerId);
+        Mockito.doReturn(practitionerOrganizationIds)
+                .when(mockPractitionerDetailsEndpointHelper)
+                .getOrganizationIdsByPractitionerRoles(practitionerRoleList);
+        Mockito.doReturn(organizationAffiliationsBundle)
+                .when(mockPractitionerDetailsEndpointHelper)
+                .getOrganizationAffiliationsByOrganizationIdsBundle(combinedOrganizationIds);
+        Mockito.doReturn(organizationAffiliations)
+                .when(mockPractitionerDetailsEndpointHelper)
+                .mapBundleToOrganizationAffiliation(organizationAffiliationsBundle);
+        Mockito.doReturn(locationIds)
+                .when(mockPractitionerDetailsEndpointHelper)
+                .getLocationIdsByOrganizationAffiliations(organizationAffiliations);
+
+        Mockito.doCallRealMethod()
+                .when(mockPractitionerDetailsEndpointHelper)
+                .getPractitionerLocationIdsByByKeycloakIdCore(practitionerId);
+        List<String> resultLocationIds =
+                mockPractitionerDetailsEndpointHelper.getPractitionerLocationIdsByByKeycloakIdCore(
+                        practitionerId);
+
+        Assert.assertNotNull(resultLocationIds);
+        Assert.assertEquals(1, resultLocationIds.size());
+        Assert.assertEquals("Location/1234", resultLocationIds.get(0));
+    }
+
     private Bundle getPractitionerBundle() {
         Bundle bundlePractitioner = new Bundle();
         bundlePractitioner.setId("Practitioner/1234");
@@ -574,5 +640,29 @@ public class PractitionerDetailsEndpointHelperTest {
         participant.setMember(new Reference("Practitioner/1234"));
         careTeam.addParticipant(participant);
         return careTeam;
+    }
+
+    private Bundle getOrganizationAffiliationsBundle() {
+        Bundle bundle = new Bundle();
+        bundle.setId("OrganizationAffiliationsBundle/1234");
+        Bundle.BundleEntryComponent bundleEntryComponent = new Bundle.BundleEntryComponent();
+        OrganizationAffiliation organizationAffiliation = getOrganizationAffiliation();
+        bundleEntryComponent.setResource(organizationAffiliation);
+        bundle.addEntry(bundleEntryComponent);
+        return bundle;
+    }
+
+    private List<PractitionerRole> getPractitionerRoleList() {
+        PractitionerRole practitionerRole = new PractitionerRole();
+        practitionerRole.setId("PractitionerRole/1234");
+        Reference organizationRef = new Reference();
+        organizationRef.setReference("Organization/1234");
+        practitionerRole.setOrganization(organizationRef);
+        Reference practitionerRef = new Reference();
+        practitionerRef.setReference("Practitioner/1234");
+        practitionerRole.setPractitioner(practitionerRef);
+        List<PractitionerRole> practitionerRoles = new ArrayList<>();
+        practitionerRoles.add(practitionerRole);
+        return practitionerRoles;
     }
 }


### PR DESCRIPTION
-  Instead of fetching entire practitionerdetails then getting locations, just get the locations.
- replace for loops with streams
 - use sets instead of lists to avoid duplication
 - switch from using DFS to BFS in getting locations deep in the hierarchy

Resolves #82 

**Engineer Checklist**

- [ ] I have written **Unit tests** for any new feature(s) and edge cases for
      bug fixes
- [ ] I have added documentation for any new feature(s) and configuration
      option(s) on the `README.md`
- [ ] I have run `mvn spotless:check` to check my code follows the project's
      style guide
- [ ] I have run `mvn clean test jacoco:report` to confirm the coverage report
      was generated at `plugins/target/site/jacoco/index.html`
- [ ] I ran `mvn clean package` right before creating this pull request.
