### PR TITLE
Fix LocationHierarchy.getLocationId fails for Pagination endpoints 🐛

### DIFF
--- a/exec/pom.xml
+++ b/exec/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.smartregister</groupId>
     <artifactId>opensrp-gateway-plugin</artifactId>
-    <version>2.2.4</version>
+    <version>2.2.5</version>
   </parent>
 
   <artifactId>exec</artifactId>
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>org.smartregister</groupId>
       <artifactId>plugins</artifactId>
-      <version>2.2.4</version>
+      <version>2.2.5</version>
     </dependency>
 
     <dependency>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.smartregister</groupId>
     <artifactId>opensrp-gateway-plugin</artifactId>
-    <version>2.2.4</version>
+    <version>2.2.5</version>
   </parent>
 
   <artifactId>plugins</artifactId>

--- a/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/LocationHierarchyEndpointHelper.java
+++ b/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/LocationHierarchyEndpointHelper.java
@@ -14,7 +14,14 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.hl7.fhir.instance.model.api.IBaseBundle;
-import org.hl7.fhir.r4.model.*;
+import org.hl7.fhir.r4.model.Binary;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Composition;
+import org.hl7.fhir.r4.model.ListResource;
+import org.hl7.fhir.r4.model.Location;
+import org.hl7.fhir.r4.model.Resource;
+import org.hl7.fhir.r4.model.ResourceType;
+import org.hl7.fhir.r4.model.StringType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.smartregister.model.location.LocationHierarchy;

--- a/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/LocationHierarchyEndpointHelper.java
+++ b/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/LocationHierarchyEndpointHelper.java
@@ -14,13 +14,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.hl7.fhir.instance.model.api.IBaseBundle;
-import org.hl7.fhir.r4.model.Binary;
-import org.hl7.fhir.r4.model.Bundle;
-import org.hl7.fhir.r4.model.Composition;
-import org.hl7.fhir.r4.model.ListResource;
-import org.hl7.fhir.r4.model.Location;
-import org.hl7.fhir.r4.model.Resource;
-import org.hl7.fhir.r4.model.StringType;
+import org.hl7.fhir.r4.model.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.smartregister.model.location.LocationHierarchy;
@@ -204,7 +198,11 @@ public class LocationHierarchyEndpointHelper {
         try {
             location =
                     getFhirClientForR4()
-                            .fetchResourceFromUrl(Location.class, "Location/" + locationId);
+                            .fetchResourceFromUrl(
+                                    Location.class,
+                                    "Location/"
+                                            + Utils.extractLogicalId(
+                                                    ResourceType.Location, locationId));
         } catch (ResourceNotFoundException e) {
             logger.error(e.getMessage());
         }

--- a/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/Utils.java
+++ b/plugins/src/main/java/org/smartregister/fhir/gateway/plugins/Utils.java
@@ -21,6 +21,7 @@ import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Composition;
 import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.Resource;
+import org.hl7.fhir.r4.model.ResourceType;
 import org.hl7.fhir.r4.model.StringType;
 import org.hl7.fhir.r4.model.UriType;
 
@@ -282,5 +283,22 @@ public class Utils {
         return originalUrl.indexOf('?') > -1
                 ? fhirServerBaseUrl + originalUrl.substring(originalUrl.indexOf('?'))
                 : fhirServerBaseUrl;
+    }
+
+    public static String extractLogicalId(ResourceType resourceType, String url) {
+        String prefix = resourceType.name() + "/";
+
+        int prefixIndex = url.indexOf(prefix);
+        if (prefixIndex == -1) {
+            return url;
+        }
+
+        int idStartIndex = prefixIndex + prefix.length();
+        int idEndIndex = url.indexOf('/', idStartIndex);
+        if (idEndIndex == -1) {
+            idEndIndex = url.length();
+        }
+
+        return url.substring(idStartIndex, idEndIndex);
     }
 }

--- a/plugins/src/test/java/org/smartregister/fhir/gateway/plugins/UtilsTest.java
+++ b/plugins/src/test/java/org/smartregister/fhir/gateway/plugins/UtilsTest.java
@@ -10,7 +10,14 @@ import java.util.List;
 import java.util.Map;
 
 import org.hl7.fhir.instance.model.api.IBaseBundle;
-import org.hl7.fhir.r4.model.*;
+import org.hl7.fhir.r4.model.Base64BinaryType;
+import org.hl7.fhir.r4.model.Binary;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Composition;
+import org.hl7.fhir.r4.model.Identifier;
+import org.hl7.fhir.r4.model.Meta;
+import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.ResourceType;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;

--- a/plugins/src/test/java/org/smartregister/fhir/gateway/plugins/UtilsTest.java
+++ b/plugins/src/test/java/org/smartregister/fhir/gateway/plugins/UtilsTest.java
@@ -10,13 +10,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.hl7.fhir.instance.model.api.IBaseBundle;
-import org.hl7.fhir.r4.model.Base64BinaryType;
-import org.hl7.fhir.r4.model.Binary;
-import org.hl7.fhir.r4.model.Bundle;
-import org.hl7.fhir.r4.model.Composition;
-import org.hl7.fhir.r4.model.Identifier;
-import org.hl7.fhir.r4.model.Meta;
-import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.*;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -347,5 +341,20 @@ public class UtilsTest {
                         userId, syncStrategy, parameters);
 
         Assert.assertEquals(userId, result);
+    }
+
+    @Test
+    public void testExtractLogicalIdExtractsValueFromURL() {
+
+        String url = "http://my-fhir-server:8080/fhir/Location/6969/_history/2/";
+        String result = Utils.extractLogicalId(ResourceType.Location, url);
+
+        Assert.assertEquals("6969", result);
+    }
+
+    @Test
+    public void testExtractLogicalIdReturnsRawValue() {
+        String result = Utils.extractLogicalId(ResourceType.Location, "7777");
+        Assert.assertEquals("7777", result);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.smartregister</groupId>
   <artifactId>opensrp-gateway-plugin</artifactId>
-  <version>2.2.4</version>
+  <version>2.2.5</version>
   <packaging>pom</packaging>
 
   <modules>


### PR DESCRIPTION
- Fixes LocationHierarchy.getLocationId fails for Pagination endpoints 
- Release version 2.2.5

**Engineer Checklist**

- [x] I have written **Unit tests** for any new feature(s) and edge cases for
      bug fixes
- [x] I have added documentation for any new feature(s) and configuration
      option(s) on the `README.md`
- [x] I have run `mvn spotless:check` to check my code follows the project's
      style guide
- [x] I have run `mvn clean test jacoco:report` to confirm the coverage report
      was generated at `plugins/target/site/jacoco/index.html`
- [x] I ran `mvn clean package` right before creating this pull request.
