### PR TITLE
Pin docker publish workflow to Ubuntu 22

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   # Run image build test
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event_name == 'pull_request'
 
     steps:
@@ -29,7 +29,7 @@ jobs:
         run: docker build . --file Dockerfile
 
   push:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
 
     steps:


### PR DESCRIPTION
**IMPORTANT: Where possible all PRs must be linked to a Github issue**

Pin to Ubuntu v22.04
- Resolves Docker Publish workflow fails