### PR TITLE
Upgrade dependency versions

### DIFF
--- a/exec/pom.xml
+++ b/exec/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.smartregister</groupId>
     <artifactId>opensrp-gateway-plugin</artifactId>
-    <version>3.0.5</version>
+    <version>3.1.0</version>
   </parent>
 
   <artifactId>exec</artifactId>
@@ -12,8 +12,7 @@
 
   <properties>
     <root.basedir>${project.parent.basedir}</root.basedir>
-    <spring-boot.version>3.3.4</spring-boot.version>
-    <fhir.opensrp.plugins>3.0.5</fhir.opensrp.plugins>
+    <fhir.opensrp.plugins>3.1.0</fhir.opensrp.plugins>
     <!-- We do not want to deploy the `exec` uber jar. -->
     <maven.deploy.skip>true</maven.deploy.skip>
   </properties>

--- a/exec/src/main/java/org/smartregister/fhir/gateway/MainApp.java
+++ b/exec/src/main/java/org/smartregister/fhir/gateway/MainApp.java
@@ -2,7 +2,7 @@ package org.smartregister.fhir.gateway;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.web.servlet.ServletComponentScan;
+import org.springframework.boot.web.server.servlet.context.ServletComponentScan;
 
 /**
  * This class shows the minimum that is required to create a FHIR Gateway with all AccessChecker

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.smartregister</groupId>
     <artifactId>opensrp-gateway-plugin</artifactId>
-    <version>3.0.5</version>
+    <version>3.1.0</version>
   </parent>
 
   <artifactId>plugins</artifactId>
@@ -14,10 +14,9 @@
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
     <project.basedir>${project.basedir}</project.basedir>
-    <hapifhir.version>7.4.3</hapifhir.version>
-    <fhir.proxy-plugin.version>0.2.0</fhir.proxy-plugin.version>
-    <sentry.version>7.15.0</sentry.version>
-    <jakarta-servlet.version>6.0.0</jakarta-servlet.version>
+    <hapifhir.version>8.0.0</hapifhir.version>
+    <sentry.version>7.22.6</sentry.version>
+    <jakarta-servlet.version>6.1.0</jakarta-servlet.version>
     <fhir.commons.utils>1.0.4-SNAPSHOT</fhir.commons.utils>
   </properties>
 

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -17,7 +17,7 @@
     <hapifhir.version>8.0.0</hapifhir.version>
     <sentry.version>7.22.6</sentry.version>
     <jakarta-servlet.version>6.1.0</jakarta-servlet.version>
-    <fhir.commons.utils>1.0.4-SNAPSHOT</fhir.commons.utils>
+    <fhir.commons.utils>1.0.5-SNAPSHOT</fhir.commons.utils>
   </properties>
 
   <dependencies>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -15,7 +15,7 @@
     <maven.compiler.target>17</maven.compiler.target>
     <project.basedir>${project.basedir}</project.basedir>
     <hapifhir.version>8.0.0</hapifhir.version>
-    <sentry.version>7.22.6</sentry.version>
+    <sentry.version>8.32.0</sentry.version>
     <jakarta-servlet.version>6.1.0</jakarta-servlet.version>
     <fhir.commons.utils>1.0.5-SNAPSHOT</fhir.commons.utils>
   </properties>

--- a/plugins/src/test/java/org/smartregister/fhir/gateway/plugins/TestRequestDetailsToReader.java
+++ b/plugins/src/test/java/org/smartregister/fhir/gateway/plugins/TestRequestDetailsToReader.java
@@ -12,6 +12,7 @@ import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.api.RequestTypeEnum;
 import ca.uhn.fhir.rest.api.RestOperationTypeEnum;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
 
 // Note instances of this class are expected to be one per thread and this class is not thread-safe
 // the same way the underlying `requestDetails` is not.
@@ -91,5 +92,10 @@ public class TestRequestDetailsToReader implements RequestDetailsReader {
 
     public byte[] loadRequestContents() {
         return requestDetails.loadRequestContents();
+    }
+
+    @Override
+    public String getServletRequestRemoteAddr() {
+        return ((ServletRequestDetails) requestDetails).getServletRequest().getRemoteAddr();
     }
 }

--- a/plugins/src/test/java/org/smartregister/fhir/gateway/plugins/helper/PractitionerDetailsEndpointHelperTest.java
+++ b/plugins/src/test/java/org/smartregister/fhir/gateway/plugins/helper/PractitionerDetailsEndpointHelperTest.java
@@ -149,7 +149,9 @@ public class PractitionerDetailsEndpointHelperTest {
         ctx.registerCustomType(LocationHierarchy.class);
         IParser parser = ctx.newJsonParser();
         LocationHierarchy locationHierarchy =
-                (LocationHierarchy) parser.parseResource(locationHierarchyNoParentChildren);
+                (LocationHierarchy)
+                        parser.parseResource(
+                                LocationHierarchy.class, locationHierarchyNoParentChildren);
 
         List<LocationHierarchy> hierarchies = Collections.singletonList(locationHierarchy);
         Set<String> attributedLocationIds =

--- a/pom.xml
+++ b/pom.xml
@@ -6,12 +6,12 @@
     implementations do not have to do this; they can redeclare those deps. -->
     <groupId>com.google.fhir.gateway</groupId>
     <artifactId>fhir-gateway</artifactId>
-    <version>0.4.0</version>
+    <version>0.5.0</version>
   </parent>
 
   <groupId>org.smartregister</groupId>
   <artifactId>opensrp-gateway-plugin</artifactId>
-  <version>3.0.5</version>
+  <version>3.1.0</version>
   <packaging>pom</packaging>
 
   <modules>
@@ -20,10 +20,10 @@
   </modules>
 
   <properties>
-    <spotless.version>2.43.0</spotless.version>
-    <fhir.gateway.version>0.4.0</fhir.gateway.version>
-    <spring-boot.version>3.3.4</spring-boot.version>
-    <micrometer.version>1.13.7-SNAPSHOT</micrometer.version>
+    <spotless.version>3.2.1</spotless.version>
+    <fhir.gateway.version>0.5.0</fhir.gateway.version>
+    <spring-boot.version>4.0.2</spring-boot.version>
+    <micrometer.version>1.16.2</micrometer.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
This PR migrates to the latest version of the FHIR Gateway [(v0.5.0)](https://github.com/google/fhir-gateway/releases/tag/0.5.0) and other dependencies.

**Engineer Checklist**

- [x] I have written **Unit tests** for any new feature(s) and edge cases for
      bug fixes
- [x] I have added documentation for any new feature(s) and configuration
      option(s) on the `README.md`
- [x] I have run `mvn spotless:check` to check my code follows the project's
      style guide
- [x] I have run `mvn clean test jacoco:report` to confirm the coverage report
      was generated at `plugins/target/site/jacoco/index.html`
- [x] I ran `mvn clean package` right before creating this pull request.
