### PR TITLE
Spring boot v3 downgrade

### DIFF
--- a/exec/pom.xml
+++ b/exec/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.smartregister</groupId>
     <artifactId>opensrp-gateway-plugin</artifactId>
-    <version>3.1.1</version>
+    <version>3.2.0</version>
   </parent>
 
   <artifactId>exec</artifactId>
@@ -12,7 +12,7 @@
 
   <properties>
     <root.basedir>${project.parent.basedir}</root.basedir>
-    <fhir.opensrp.plugins>3.1.1</fhir.opensrp.plugins>
+    <fhir.opensrp.plugins>3.2.0</fhir.opensrp.plugins>
     <!-- We do not want to deploy the `exec` uber jar. -->
     <maven.deploy.skip>true</maven.deploy.skip>
   </properties>

--- a/exec/pom.xml
+++ b/exec/pom.xml
@@ -42,22 +42,10 @@
       <version>${hapifhir_version}</version>
     </dependency>
 
-    <dependency>
-      <groupId>ca.uhn.hapi.fhir</groupId>
-      <artifactId>hapi-fhir-client</artifactId>
-      <version>${hapifhir_version}</version>
-    </dependency>
-
     <!-- This merges the server and sample plugins together -->
     <dependency>
       <groupId>com.google.fhir.gateway</groupId>
       <artifactId>server</artifactId>
-      <version>${fhir.gateway.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>com.google.fhir.gateway</groupId>
-      <artifactId>plugins</artifactId>
       <version>${fhir.gateway.version}</version>
     </dependency>
 
@@ -80,11 +68,6 @@
       <version>${fhir.opensrp.plugins}</version>
     </dependency>
 
-    <dependency>
-      <groupId>ca.uhn.hapi.fhir</groupId>
-      <artifactId>hapi-fhir-client</artifactId>
-      <version>${hapifhir_version}</version>
-    </dependency>
   </dependencies>
 
   <build>

--- a/exec/src/main/java/org/smartregister/fhir/gateway/MainApp.java
+++ b/exec/src/main/java/org/smartregister/fhir/gateway/MainApp.java
@@ -2,14 +2,16 @@ package org.smartregister.fhir.gateway;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.web.server.servlet.context.ServletComponentScan;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.web.servlet.ServletComponentScan;
 
 /**
  * This class shows the minimum that is required to create a FHIR Gateway with all AccessChecker
  * plugins defined in "com.google.fhir.gateway.plugin" and "org.smartregister.fhir.gateway.plugins.
  */
 @SpringBootApplication(
-        scanBasePackages = {"org.smartregister.fhir.gateway", "com.google.fhir.gateway.plugin"})
+        scanBasePackages = {"org.smartregister.fhir.gateway", "com.google.fhir.gateway.plugin"},
+        exclude = {DataSourceAutoConfiguration.class})
 @ServletComponentScan({"org.smartregister.fhir.gateway.plugins", "com.google.fhir.gateway"})
 public class MainApp {
 

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.smartregister</groupId>
     <artifactId>opensrp-gateway-plugin</artifactId>
-    <version>3.1.1</version>
+    <version>3.2.0</version>
   </parent>
 
   <artifactId>plugins</artifactId>
@@ -15,7 +15,7 @@
     <maven.compiler.target>17</maven.compiler.target>
     <project.basedir>${project.basedir}</project.basedir>
     <hapifhir.version>8.0.0</hapifhir.version>
-    <sentry.version>8.34.1</sentry.version>
+    <sentry.version>8.40.0</sentry.version>
     <jakarta-servlet.version>6.1.0</jakarta-servlet.version>
     <fhir.commons.utils>1.0.5-SNAPSHOT</fhir.commons.utils>
   </properties>
@@ -55,7 +55,7 @@
     </dependency>
     <dependency>
       <groupId>io.sentry</groupId>
-      <artifactId>sentry-spring-boot-4</artifactId>
+      <artifactId>sentry-spring-boot-starter-jakarta</artifactId>
       <version>${sentry.version}</version>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.smartregister</groupId>
   <artifactId>opensrp-gateway-plugin</artifactId>
-  <version>3.1.1</version>
+  <version>3.2.0</version>
   <packaging>pom</packaging>
 
   <modules>
@@ -22,7 +22,7 @@
   <properties>
     <spotless.version>3.2.1</spotless.version>
     <fhir.gateway.version>0.5.0</fhir.gateway.version>
-    <spring-boot.version>4.0.2</spring-boot.version>
+    <spring-boot.version>3.5.14</spring-boot.version>
     <micrometer.version>1.16.2</micrometer.version>
   </properties>
 


### PR DESCRIPTION
**IMPORTANT: Where possible all PRs must be linked to a Github issue**

Conflicting versions of the Spring Boot framework was causing instability issues with the FHIR Gateway. This PR downgrades back to v3 to align with the Gateway.

**Engineer Checklist**

- [x] I have written **Unit tests** for any new feature(s) and edge cases for
      bug fixes
- [x] I have added documentation for any new feature(s) and configuration
      option(s) on the `README.md`
- [x] I have run `mvn spotless:check` to check my code follows the project's
      style guide
- [x] I have run `mvn clean test jacoco:report` to confirm the coverage report
      was generated at `plugins/target/site/jacoco/index.html`
- [x] I ran `mvn clean package` right before creating this pull request.
